### PR TITLE
Make all the October classes stay visible.

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -30,7 +30,7 @@ Route::get('/board', function() {
 
 Route::get('/classes', function() {
     return view('web.static.classes', [
-        'courses' => Course::whereDate('start', '>=', date('Y-m-d'))->orderBy('start')->get(),
+        'courses' => Course::whereDate('start', '>=', '2024-10-13')->orderBy('start')->get(),
     ]);
 });
 


### PR DESCRIPTION
This is NOT a long term solution, just a patch to allow late sign ups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the `/classes` route to filter courses starting from a fixed date of October 13, 2024, improving the relevance of displayed course information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->