### PR TITLE
Redirect registration

### DIFF
--- a/app/Http/Controllers/RegistrationController.php
+++ b/app/Http/Controllers/RegistrationController.php
@@ -62,6 +62,10 @@ class RegistrationController extends Controller
         if (!$course || $course->status != 'open') {
             abort(404);
         }
+        // If the course has an alternate registration URL, redirect to it.
+        if ($course->alt_url) {
+            return redirect($course->alt_url);
+        }
         return view("web.public.register", compact('course'));
     }
 


### PR DESCRIPTION
If a course has an alt_url for registration, don't show our form, just redirect there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced registration process with redirection to alternate registration URLs for specific courses. 

- **Bug Fixes**
	- Improved user experience by ensuring users are directed to the correct registration link if available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->