### PR TITLE
Allow continuous classes

### DIFF
--- a/resources/views/web/public/register.blade.php
+++ b/resources/views/web/public/register.blade.php
@@ -14,7 +14,8 @@
           @if ($course->duration == 5)
             This class meets daily {{ $course->start->format('M d') }} through {{ $course->end->format('M d') }} from {{ $course->start->format('g:i A') }} to {{ $course->end->format('g:i A') }}.
           @elseif ($course->duration == 99)
-            This class meets {{ strtolower($course->start->format('l')) }}s at {{ $course->start->format('g:i A') }}.
+            This is an open enrollment group that meets {{ strtolower($course->start->format('l')) }}s at {{ $course->start->format('g:i A') }}.
+            You may join at any time during the year.
           @else
             This class meets {{ strtolower($course->start->format('l')) }}s at {{ $course->start->format('g:i A') }} for {{ $course->duration }} weeks starting {{ $course->start->format('M d') }}.
           @endif

--- a/resources/views/web/public/register.blade.php
+++ b/resources/views/web/public/register.blade.php
@@ -13,6 +13,8 @@
         <p class="mt-6 text-lg leading-8">
           @if ($course->duration == 5)
             This class meets daily {{ $course->start->format('M d') }} through {{ $course->end->format('M d') }} from {{ $course->start->format('g:i A') }} to {{ $course->end->format('g:i A') }}.
+          @elseif ($course->duration == 99)
+            This class meets {{ strtolower($course->start->format('l')) }}s at {{ $course->start->format('g:i A') }}.
           @else
             This class meets {{ strtolower($course->start->format('l')) }}s at {{ $course->start->format('g:i A') }} for {{ $course->duration }} weeks starting {{ $course->start->format('M d') }}.
           @endif

--- a/resources/views/web/static/classes.blade.php
+++ b/resources/views/web/static/classes.blade.php
@@ -30,6 +30,8 @@
                     {{ $course->start->format('l M d') }} at {{ $course->start->format('g:i A') }}
                 @elseif ($course->duration == 5)
                     {{ $course->start->format('l M d') }} to {{ $course->end->format('l M d') }} daily {{ $course->start->format('g:i A') }} - {{ $course->end->format('g:i A') }}
+                @elseif ($course->duration == 99)
++                   {{ $course->start->format('l') }}s at {{ $course->start->format('g:i A') }} (Open Enrollment)
                 @else
                     {{ $course->start->format('l') }}s at {{ $course->start->format('g:i A') }}
                 @endif

--- a/resources/views/web/static/classes.blade.php
+++ b/resources/views/web/static/classes.blade.php
@@ -7,8 +7,7 @@
     <header class="mx-auto max-w-2xl md:text-center px-2">
         <h1 class="mt-4 text-3xl font-bold tracking-tight text-gray-dark sm:text-4xl">Classes</h1>
         <p class="mt-6 text-lg">
-            Ensembles typically runs six week sessions of group lessons. The next
-            session is a special 3 week holiday session beginning
+            This session is a special 3 week holiday session beginning
             <em class="font-bold">December 2, 2024</em> and registration opens
             Nov 2.
             The cost of the three-week holiday session is $45 per student. Scholarships

--- a/routes/web.php
+++ b/routes/web.php
@@ -31,7 +31,8 @@ Route::get('/board', function() {
 Route::get('/classes', function() {
     return view('web.static.classes', [
         'courses' => Course::whereDate('start', '>=', date('Y-m-d'))
-         ->orWhere('duration', '=', 99)->orderBy('start')->get(),
+         ->orWhere('duration', '=', 99)
+         ->orderBy('start')->get(),
     ]);
 });
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -30,7 +30,8 @@ Route::get('/board', function() {
 
 Route::get('/classes', function() {
     return view('web.static.classes', [
-        'courses' => Course::whereDate('start', '>=', date('Y-m-d'))->orderBy('start')->get(),
+        'courses' => Course::whereDate('start', '>=', date('Y-m-d'))
+         ->orWhere('duration', '=', 99)->orderBy('start')->get(),
     ]);
 });
 


### PR DESCRIPTION
If a class has duration 99 is is an "open" class and students can join at any time during the year.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced registration form to display specific course details for a duration of 99 days.
	- Updated class session description to highlight a special 3-week holiday session starting December 2, 2024.
	- Expanded course retrieval logic to include courses with a duration of 99 days in the `/classes` endpoint.

- **Bug Fixes**
	- Improved clarity of course information presented to users during registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->