### PR TITLE
Add the Summer 2025 landing page.

### DIFF
--- a/resources/views/web/static/minis.blade.php
+++ b/resources/views/web/static/minis.blade.php
@@ -1,6 +1,6 @@
 @extends('web.layouts.master')
 
-@section('title', 'Piano Camp')
+@section('title', 'Mini Musicians')
 
 @section('content')
 

--- a/resources/views/web/static/summer2025.blade.php
+++ b/resources/views/web/static/summer2025.blade.php
@@ -30,7 +30,7 @@
             <h2 class="text-2xl font-bold text-primary mb-3">Piano Camps</h2>
             <p class="text-gray-dark mb-4">
                 Whether you are a beginner, have some experience, or are a seasoned pianist, our piano camps offer the perfect environment
-                have fun and develop your skills. We'll have lessons, games, and performance opportunities.
+                to have fun and develop your skills. We'll have lessons, games, and performance opportunities.
                 Join us Monday June 23 to Friday June 27 daily 9:00 AM - 12:00 PM (ages 8-12) or 1:00 PM - 4:00 PM (ages 13-18).
             </p>
             <a href="{{ route('piano-camp') }}" class="w-32 inline-block bg-primary text-white px-4 py-2 rounded-md hover:bg-primary-dark text-center">Go Piano!</a>

--- a/resources/views/web/static/summer2025.blade.php
+++ b/resources/views/web/static/summer2025.blade.php
@@ -1,0 +1,49 @@
+@extends('web.layouts.master')
+
+@section('title', 'Summer 2025')
+
+@section('content')
+<article class="mx-auto max-w-7xl px-6">
+    <h1 class="mt-4 text-3xl font-bold tracking-tight text-gray-dark sm:text-4xl text-center mb-8">Summer 2025</h1>
+
+    <div class="grid md:grid-cols-2 gap-8">
+        <div class="bg-white p-6 rounded-lg shadow-md">
+            <h2 class="text-2xl font-bold text-primary mb-3">Making Slime Together</h2>
+            <p class="text-gray-dark mb-4">
+                Join us to create together for a great cause! Saturday May 17th 1:00-3:30 Ben and Crystal Woods from Look out for the Left Out
+                will be organizing us to make SLIME together that will benefit the Casa Calla House for vulnerable girls in Romania.
+                Plus there will be other fun surprises as well as door prizes and ice cream provided by the NWSB Fun Truck
+            </p>
+            <a href="{{ route('make-slime') }}" class="w-32 inline-block bg-primary text-white px-4 py-2 rounded-md hover:bg-primary-dark text-center">Make Slime!</a>
+        </div>
+
+        <div class="bg-white p-6 rounded-lg shadow-md">
+            <h2 class="text-2xl font-bold text-primary mb-3">Pirate Music Camp</h2>
+            <p class="text-gray-dark mb-4">
+                Set sail on a musical adventure with our pirate-themed music camp. Students will learn sea shanties, play fun games, and develop their musical skills.
+                Join us Monday June 16 to Friday June 20 daily 9:00 AM - 12:00 PM. Open to students ages 5-11.
+            </p>
+            <a href="{{ route('music-camp') }}" class="w-32 inline-block bg-primary text-white px-4 py-2 rounded-md hover:bg-primary-dark text-center">Ahoy!</a>
+        </div>
+
+        <div class="bg-white p-6 rounded-lg shadow-md">
+            <h2 class="text-2xl font-bold text-primary mb-3">Piano Camps</h2>
+            <p class="text-gray-dark mb-4">
+                Whether you are a beginner, have some experience, or are a seasoned pianist, our piano camps offer the perfect environment
+                have fun and develop your skills. We'll have lessons, games, and performance opportunities.
+                Join us Monday June 23 to Friday June 27 daily 9:00 AM - 12:00 PM (ages 8-12) or 1:00 PM - 4:00 PM (ages 13-18).
+            </p>
+            <a href="{{ route('piano-camp') }}" class="w-32 inline-block bg-primary text-white px-4 py-2 rounded-md hover:bg-primary-dark text-center">Go Piano!</a>
+        </div>
+
+        <div class="bg-white p-6 rounded-lg shadow-md">
+            <h2 class="text-2xl font-bold text-primary mb-3">Summer Art Camp</h2>
+            <p class="text-gray-dark mb-4">
+                Launch your student's love for art with our space-themed art camp! Students will explore various mediums including drawing, sculpture, painting, and more.
+                Join us Monday July 14 to Thursday July 17 daily 10:00 AM - 12:00 PM. Open to students ages 6-11.
+            </p>
+            <a href="{{ route('art-camp') }}" class="w-32 inline-block bg-primary text-white px-4 py-2 rounded-md hover:bg-primary-dark text-center">Blast off!</a>
+        </div>
+    </div>
+</article>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -72,13 +72,15 @@ Route::get('/volunteer', function() {
     return view('web.static.volunteer');
 });
 
-Route::view('/piano-camp', 'web.static.piano-camp');
+Route::view('/piano-camp', 'web.static.piano-camp')->name('piano-camp');
 
-Route::view('/music-camp', 'web.static.music-camp');
+Route::view('/music-camp', 'web.static.music-camp')->name('music-camp');
 
-Route::view('/art-camp', 'web.static.art-camp');
+Route::view('/art-camp', 'web.static.art-camp')->name('art-camp');
 
-Route::view('/make-slime', 'web.static.make-slime');
+Route::view('/summer2025', 'web.static.summer2025')->name('summer2025');
+
+Route::view('/make-slime', 'web.static.make-slime')->name('make-slime');
 
 Route::view('/minis', 'web.static.minis');
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -82,7 +82,7 @@ Route::view('/summer2025', 'web.static.summer2025')->name('summer2025');
 
 Route::view('/make-slime', 'web.static.make-slime')->name('make-slime');
 
-Route::view('/minis', 'web.static.minis');
+Route::view('/minis', 'web.static.minis')->name('minis');
 
 Route::get('/gallery/rhythm', function() {
     return view('web.art-gallery.rhythm-show');


### PR DESCRIPTION
Add landing page to go with the summer 2025 flier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the webpage title from "Piano Camp" to "Mini Musicians."
  - Introduced a new Summer 2025 page showcasing various program offerings with a responsive design layout.
  - Enhanced navigation with updated and clearly named routes for improved access to program pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->