### PR TITLE
Update the Session dates.

### DIFF
--- a/resources/views/web/static/classes.blade.php
+++ b/resources/views/web/static/classes.blade.php
@@ -7,8 +7,11 @@
     <header class="mx-auto max-w-2xl md:text-center px-2">
         <h1 class="mt-4 text-3xl font-bold tracking-tight text-gray-dark sm:text-4xl">Classes</h1>
         <p class="mt-6 text-lg">
-            Ensembles typically runs six week sessions of group lessons. The next session runs from
-            <em class="font-bold">August 4 through September 12</em>.
+            Ensembles typically runs six week sessions of group lessons. To accommodate GCCS fall break,
+            this session is split into two three week parts <span class="font-bold">September 15 - October 3</span> ,
+            and <span class="font-bold">October  13 - October 31</span> with
+            <span class="font-bold">no classes October 6-10</span>.
+
             The cost of the six-week session is $75 per student.
             Scholarships are available.
         </p>

--- a/resources/views/web/static/classes.blade.php
+++ b/resources/views/web/static/classes.blade.php
@@ -8,8 +8,8 @@
         <h1 class="mt-4 text-3xl font-bold tracking-tight text-gray-dark sm:text-4xl">Classes</h1>
         <p class="mt-6 text-lg">
             Ensembles typically runs six week sessions of group lessons. To accommodate GCCS fall break,
-            this session is split into two three week parts <span class="font-bold">September 15 - October 3</span> ,
-            and <span class="font-bold">October  13 - October 31</span> with
+            this session is split into two three week parts <span class="font-bold">September 15 - October 3</span>,
+            and <span class="font-bold">October 13 - October 31</span> with
             <span class="font-bold">no classes October 6-10</span>.
 
             The cost of the six-week session is $75 per student.

--- a/resources/views/web/static/welcome.blade.php
+++ b/resources/views/web/static/welcome.blade.php
@@ -23,7 +23,7 @@
                     class="text-4xl text-primary-light tracking-tight leading-10 font-medium sm:text-5xl sm:leading-none md:text-6xl">
                     Classes</h2>
                 <p class="mt-3 text-gray-mist sm:mt-5 sm:text-lg sm:max-w-xl sm:mx-auto md:mt-5">
-                    Our next session of classes starts August 4.
+                    Our next session of classes starts September 15.
                 </p>
                 <a href="/classes"
                     class="mt-6 inline-flex items-center justify-center whitespace-nowrap rounded-md border border-transparent bg-primary px-4 py-2 text-base font-medium text-white shadow-sm hover:bg-primary-dark">Learn


### PR DESCRIPTION
That time again

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an Open Enrollment indicator in course listings for applicable classes, showing start weekday, start time, and “(Open Enrollment)”.

- Content Updates
  - Updated class schedule to two three-week parts (Sep 15–Oct 3 and Oct 13–Oct 31) with a no-class period Oct 6–10.
  - Updated homepage message to “Our next session of classes starts September 15.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->