### PR TITLE
Update the dates for the late fall session.

### DIFF
--- a/resources/views/web/static/classes.blade.php
+++ b/resources/views/web/static/classes.blade.php
@@ -7,10 +7,10 @@
     <header class="mx-auto max-w-2xl md:text-center px-2">
         <h1 class="mt-4 text-3xl font-bold tracking-tight text-gray-dark sm:text-4xl">Classes</h1>
         <p class="mt-6 text-lg">
-            Ensembles typically runs six week sessions of group lessons. To accommodate GCCS fall break,
-            this session is split into two three week parts <span class="font-bold">September 15 - October 3</span>,
-            and <span class="font-bold">October 13 - October 31</span> with
-            <span class="font-bold">no classes October 6-10</span>.
+            Ensembles typically runs six week sessions of group lessons. To accommodate GCCS Thanksgiving break,
+            this session is split into two three week parts <span class="font-bold">November 3 - November 21</span>,
+            and <span class="font-bold">December 1 - December 19</span> with
+            <span class="font-bold">no classes November 24-28</span>.
 
             The cost of the six-week session is $75 per student.
             Scholarships are available.

--- a/resources/views/web/static/welcome.blade.php
+++ b/resources/views/web/static/welcome.blade.php
@@ -23,7 +23,7 @@
                     class="text-4xl text-primary-light tracking-tight leading-10 font-medium sm:text-5xl sm:leading-none md:text-6xl">
                     Classes</h2>
                 <p class="mt-3 text-gray-mist sm:mt-5 sm:text-lg sm:max-w-xl sm:mx-auto md:mt-5">
-                    Our next session of classes starts September 15.
+                    Our next session of classes starts November 3.
                 </p>
                 <a href="/classes"
                     class="mt-6 inline-flex items-center justify-center whitespace-nowrap rounded-md border border-transparent bg-primary px-4 py-2 text-base font-medium text-white shadow-sm hover:bg-primary-dark">Learn


### PR DESCRIPTION
show the dates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an “Open Enrollment” message for applicable classes, showing day-of-week and time.

- Documentation
  - Updated classes information to reflect GCCS Thanksgiving break: sessions now run Nov 3–21 and Dec 1–19; no classes Nov 24–28.
  - Updated the welcome page classes date from Sept 15 to Nov 3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->